### PR TITLE
Fixed Text cut on low aspect ratios

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -111,7 +111,6 @@ main article {
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    width: 1vw;
 }
 
 /* Aside */
@@ -174,23 +173,23 @@ h6.highlight {
 	aside .summary > ul {
 		display: none;
 	}
-	
+
 	aside .summary > b::after {
 		content: " >";
 	}
-	
+
 	aside:hover .summary > b:after {
 		content: " <";
 	}
-	
+
 	aside:hover .summary > ul {
 		display: block;
 	}
-	
+
 	aside {
 		max-height: 70vh;
 	}
-	
+
 	aside:hover {
 		box-shadow: 0 0 70px #000000b8, 0 0 0 99rem #8f8f8fcf;
 	}
@@ -198,7 +197,7 @@ h6.highlight {
 	article {
 		width: initial;
 	}
-	
+
 	pre {
 		padding: 8px 10px;
 		overflow: auto;


### PR DESCRIPTION
Fixed issue #2.
The article had a `width: 1vw` property in it's css, which was causing problems on certain viewport ratios.