### PR TITLE
apx,abroot: update index

### DIFF
--- a/docs/ABRoot/index.md
+++ b/docs/ABRoot/index.md
@@ -1,6 +1,6 @@
 ---
 title: Immutability (ABRoot) - Vanilla OS
-description: Utility proving full immutability and atomicity by making transactions between 2 root partitions with support for on-demand transactions via a transactional shell in Vanilla OS.
+description: Find out how to use ABRoot.
 ---
 
 # Immutability (`abroot`)
@@ -10,18 +10,18 @@ description: Utility proving full immutability and atomicity by making transacti
 ## How it works
 
 The Linux file system is a hierarchical file structure containing root and other directories. 
-Root is the primary hierarchical directory containing all other directories.
-In immutable file systems, the root partition is read-only, preventing the installation of essential packages, such as drivers on the host.
+Root is the primary hierarchical directory containing all other partitions.
+In immutable file systems, the root partition is read-only, preventing the installation of essential packages, such as drivers in the host.
 
-`abroot` allows you to install kernel modules, drivers and other essential packages without compromising on the filesystem's immutability. 
+`abroot` allows you to install kernel modules, drivers and other essential packages without compromising the filesystem's immutability. 
 
-When a command gets executed in `abroot`, a transaction is started in the transactional shell in the second root partition. If the transaction succeeds, the changes are applied using an overlay and are synced with the current root on reboot. If the transaction fails, no changes are applied (due to a property known as atomicity). `abroot` also allows for on-demand transactions using the `abroot shell` command.
+When a command gets executed in `abroot`, a transaction gets started in the transactional shell in the second root partition. If the transaction succeeds, the changes are applied using an overlay and synced with the current root on reboot. If the transaction fails, no changes are applied (due to a property known as atomicity). `abroot` also allows for on-demand transactions using the `abroot shell` command.
 
 Vanilla OS installations create root and boot partitions for both states (20GB per root partition) as it is a requirement for `abroot`.
 
 ## States
 
-`abroot` has two states - present and future. When you are in your Vanilla OS installation for the first time, the present state is A. When you reboot your system, the state automatically switches to B. When you install a package using `abroot`,  it gets installed in the future root partition and is synced with the current root partition upon reboot.
+`abroot` has two states - present and future. When you are in your Vanilla OS installation for the first time, the present state is A. When you reboot your system, the state automatically switches to B. When you install a package using `abroot`,  it gets installed in the future root partition and synced with the current root partition upon reboot.
 
 ## Updates
 
@@ -29,7 +29,7 @@ Vanilla OS installations create root and boot partitions for both states (20GB p
 
 ## Naming
 
-ABRoot's name is a reference to the two transacting root partitions A and B (A⟺B).
+ABRoot's name refers to the two transacting root partitions A and B (A⟺B).
 
 ## Usage
 

--- a/docs/ABRoot/manpage.md
+++ b/docs/ABRoot/manpage.md
@@ -52,6 +52,10 @@ Examples:
     abroot exec apt install git 
 ```
 
+```text
+Tip: You can enclose multiple commands using "" and pass it as a single string.
+```
+
 ### GET
 
 ```markdown

--- a/docs/apx/index.md
+++ b/docs/apx/index.md
@@ -39,7 +39,7 @@ Nevertheless, you can install packages from package other distributions. For exa
 container based on Arch Linux will be created. Here, `apx` will manage the packages 
 from the AUR (Pacman and yay), tightly integrating them with the host system. Using the `--dnf` flag with `apx` will create a new container based on Fedora Linux. Here, `apx` will manage packages from Fedora's DNF repository,  tightly integrating them with the host system. 
 
-For GUI packages created inside `apx` containers,`.desktop` files are created automatically and added to the Applications menu with a container indicator next to the application name. These applications are displayed beside other applications in the "Open with" menu in nautilus and the "Default applications" menu in the GNOME control center. GUI Packages installed inside containers gets shown in the Sub System section in the [Vanilla control center](/docs/vanilla-control-center).
+For GUI packages created inside `apx` containers,`.desktop` files are created automatically and added to the Applications menu with a container indicator next to the application name. These applications are displayed beside other applications in the "Open with" menu in nautilus. GUI Packages installed inside containers gets shown in the Sub System section in the [Vanilla control center](/docs/vanilla-control-center).
 
 For quality control, we are limiting this feature to specific implementations. Currently, only `--aur` and `--dnf` flags are supported, but 
 we are planning to implement support for the Nix package manager as well in future.

--- a/docs/apx/index.md
+++ b/docs/apx/index.md
@@ -26,7 +26,7 @@ software, e.g. by opening a file in LibreOffice.
 While installing software on the host is against the project's ideology, there are cases where it is essential. For example, when you need to 
 install a kernel module or driver.
 
-In cases like this, you can use the `abroot exec apt install <package_name>*` or `abroot shell apt install <package_name>` command to bypass the container and install directly on the host, *but be aware that this 
+In cases like this, you can use the `abroot exec apt install <package_name>` or `abroot shell apt install <package_name>` command to bypass the container and install directly on the host, *but be aware that this 
 is not recommended*.
 
 ### Multiple sources
@@ -37,7 +37,9 @@ package manager (`apt` for Ubuntu).
 
 Nevertheless, you can install packages from package other distributions. For example, using the `--aur` flag, a new
 container based on Arch Linux will be created. Here, `apx` will manage the packages 
-from the AUR (and Pacman), tightly integrating them with the host system. Using the `--dnf` flag with `apx` will create a new container based on Fedora Linux. Here, `apx` will manage packages from Fedora's DNF repository,  tightly integrating them with the host system. For GUI packages created inside `apx` containers,`.desktop` files are created automatically and added to the Applications menu with a container indicator next to the application name. GUI Packages installed inside containers gets shown in the Sub System section in the [Vanilla control center](/docs/vanilla-control-center).
+from the AUR (Pacman and yay), tightly integrating them with the host system. Using the `--dnf` flag with `apx` will create a new container based on Fedora Linux. Here, `apx` will manage packages from Fedora's DNF repository,  tightly integrating them with the host system. 
+
+For GUI packages created inside `apx` containers,`.desktop` files are created automatically and added to the Applications menu with a container indicator next to the application name. These applications are displayed beside other applications in the "Open with" menu in nautilus and the "Default applications" menu in the GNOME control center. GUI Packages installed inside containers gets shown in the Sub System section in the [Vanilla control center](/docs/vanilla-control-center).
 
 For quality control, we are limiting this feature to specific implementations. Currently, only `--aur` and `--dnf` flags are supported, but 
 we are planning to implement support for the Nix package manager as well in future.


### PR DESCRIPTION
## Changes

- `apx`: Fixed a typo in a command.
- `apx`: Added info about GUI applications.
- Updated `abroot` index.
- Added a tip to `abroot` exec in the manpage regarding executing multiple commands as a string using "".