### PR TITLE
improved visibility of table th

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -66,6 +66,10 @@
         background-color: #28272a;
     }
 
+    table th {
+        background-color: #28272a;
+    }
+
     tbody tr:hover {
         background-color: #2c2b2e;
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/51142471/213886103-7305b2d6-aeb2-4e4e-bdab-986311ee5f48.png)

`table th` element lacks visibility in dark mode. I've improved it 